### PR TITLE
Adding an optional engine flag, so module consumers can use Valkey as an engine

### DIFF
--- a/README-HEADER.md
+++ b/README-HEADER.md
@@ -16,7 +16,7 @@ More information can be found on these install methods and more in [the document
 
 ## Usage
 
-Provisions an Elasticache Redis cluster (with Cluster Mode Disabled).
+Provisions an Elasticache Redis (or Valkey) cluster (with Cluster Mode Disabled).
 
 > ℹ️ Note the confusing terminology around `Cluster Mode`. The `Cluster Mode` setting is a Redis feature that allows data to be sharded among nodes in a cluster, and requires some additional configuration to connect with it correctly. A Redis cluster that does not have `Cluster Mode` enabled is a set of standalone Redis nodes that have a single primary node for reading and writing and replica nodes for reading.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ More information can be found on these install methods and more in [the document
 
 ## Usage
 
-Provisions an Elasticache Redis cluster (with Cluster Mode Disabled).
+Provisions an Elasticache Redis (or Valkey) cluster (with Cluster Mode Disabled).
 
 > ℹ️ Note the confusing terminology around `Cluster Mode`. The `Cluster Mode` setting is a Redis feature that allows data to be sharded among nodes in a cluster, and requires some additional configuration to connect with it correctly. A Redis cluster that does not have `Cluster Mode` enabled is a set of standalone Redis nodes that have a single primary node for reading and writing and replica nodes for reading.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Use this URL for the source of the module. See the usage examples below for more details.
 
 ```hcl
-github.com/pbs/terraform-aws-elasticache-redis-standalone-module?ref=2.0.0
+github.com/pbs/terraform-aws-elasticache-redis-standalone-module?ref=x.y.z
 ```
 
 ### Alternative Installation Methods
@@ -28,7 +28,7 @@ Integrate this module like so:
 
 ```hcl
 module "redis" {
-  source = "github.com/pbs/terraform-aws-elasticache-redis-standalone-module?ref=2.0.0"
+  source = "github.com/pbs/terraform-aws-elasticache-redis-standalone-module?ref=x.y.z"
 
   # Tagging Parameters
   organization = var.organization
@@ -44,7 +44,7 @@ module "redis" {
 
 If this repo is added as a subtree, then the version of the module should be close to the version shown here:
 
-`2.0.0`
+`x.y.z`
 
 Note, however that subtrees can be altered as desired within repositories.
 
@@ -107,6 +107,7 @@ No modules.
 | <a name="input_dns_ttl"></a> [dns\_ttl](#input\_dns\_ttl) | TTL for DNS records. | `number` | `300` | no |
 | <a name="input_egress_cidr_blocks"></a> [egress\_cidr\_blocks](#input\_egress\_cidr\_blocks) | List of CIDR blocks to assign to the egress rule of the security group. If null, `egress_security_group_ids` must be used. | `list(string)` | <pre>[<br>  "10.0.0.0/8"<br>]</pre> | no |
 | <a name="input_egress_source_sg_id"></a> [egress\_source\_sg\_id](#input\_egress\_source\_sg\_id) | List of security group ID to assign to the egress rule of the security group. If null, `egress_cidr_blocks` must be used. | `string` | `null` | no |
+| <a name="input_engine"></a> [engine](#input\_engine) | The engine to use ('valkey' or 'redis') | `string` | `"redis"` | no |
 | <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | Version number of the cache engine to be used. If not set, defaults to the latest version. See Describe Cache Engine Versions in the AWS Documentation for supported versions. When engine is redis and the version is 6 or higher, the major and minor version can be set, e.g., 6.2, or the minor version can be unspecified which will use the latest version at creation time, e.g., 6.x. Otherwise, specify the full version desired, e.g., 5.0.6. | `string` | `null` | no |
 | <a name="input_final_snapshot_identifier"></a> [final\_snapshot\_identifier](#input\_final\_snapshot\_identifier) | Name of your final cluster snapshot. If omitted, no final snapshot will be made. | `string` | `null` | no |
 | <a name="input_global_replication_group_id"></a> [global\_replication\_group\_id](#input\_global\_replication\_group\_id) | The ID of the global replication group to which this replication group should belong. If this parameter is specified, the replication group is added to the specified global replication group as a secondary replication group; otherwise, the replication group is not part of any global replication group. If global\_replication\_group\_id is set, the num\_node\_groups parameter cannot be set. | `string` | `null` | no |

--- a/locals.tf
+++ b/locals.tf
@@ -24,8 +24,6 @@ locals {
 
   automatic_failover_enabled = var.automatic_failover_enabled != null ? var.automatic_failover_enabled : var.nodes >= 2
 
-  engine = "redis"
-
   creator = "terraform"
 
   defaulted_tags = merge(

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ resource "aws_elasticache_replication_group" "replication_group" {
   auto_minor_version_upgrade  = var.auto_minor_version_upgrade
   automatic_failover_enabled  = local.automatic_failover_enabled
   data_tiering_enabled        = var.data_tiering_enabled
-  engine                      = local.engine
+  engine                      = var.engine
   engine_version              = var.engine_version
   final_snapshot_identifier   = var.final_snapshot_identifier
   global_replication_group_id = var.global_replication_group_id

--- a/optional.tf
+++ b/optional.tf
@@ -22,6 +22,16 @@ variable "auto_minor_version_upgrade" {
   type        = bool
 }
 
+variable "engine" {
+  description = "The engine to use ('valkey' or 'redis')"
+  default     = "redis"
+  type        = string
+  validation {
+    condition     = contains(["redis", "valkey"], var.engine)
+    error_message = "Engine must be 'redis' or 'valkey'"
+  }
+}
+
 variable "engine_version" {
   description = "Version number of the cache engine to be used. If not set, defaults to the latest version. See Describe Cache Engine Versions in the AWS Documentation for supported versions. When engine is redis and the version is 6 or higher, the major and minor version can be set, e.g., 6.2, or the minor version can be unspecified which will use the latest version at creation time, e.g., 6.x. Otherwise, specify the full version desired, e.g., 5.0.6."
   default     = null


### PR DESCRIPTION
This is in support of https://pbskids.atlassian.net/browse/KAT-1448. Moreover, with Redis' new licensing, that may change if and when Redis clusters will receive engine updates. This will prep us for that eventuality and allow us to upgrade more seamlessly.